### PR TITLE
Fix to not being able to play the first item on song list

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -90,7 +90,7 @@ export default new Vuex.Store({
         
         state.playerIsLoading = true // show player loading animation on UI
 
-        state.currentTrackId = payload.trackId || state.currentTrackId // update current track id
+        state.currentTrackId = payload.trackId === 0 || payload.trackId ? payload.trackId : state.currentTrackId // update current track id
         state.audio.src = state.songs[state.currentTrackId].audio
         state.audio.play() // play audio
       }


### PR DESCRIPTION
Bug was caused by line checking the validity of 'trackId' dismissing `0` and using the current playing 'trackId'
#15 
Fixes #15 